### PR TITLE
Fix/eos account creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rights-exchange/chainjs",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Javascript helper library providing plug-in interfaces to multiple block chains.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/chains/eos_1_8/eosCreateAccount.ts
+++ b/src/chains/eos_1_8/eosCreateAccount.ts
@@ -394,15 +394,9 @@ export class EosCreateAccount implements CreateAccount {
     const publicKeys: EosPublicKeys = {}
     const { publicKeys: publicKeysFromOptions } = this._options || {}
     const { owner, active } = publicKeysFromOptions || {}
-
-    if (owner) {
-      publicKeys.owner = owner
+    if (!owner && !active) {
+      return null
     }
-
-    if (active) {
-      publicKeys.active = active
-    }
-
     return publicKeys
   }
 

--- a/src/chains/eos_1_8/eosCreateAccount.ts
+++ b/src/chains/eos_1_8/eosCreateAccount.ts
@@ -279,7 +279,7 @@ export class EosCreateAccount implements CreateAccount {
   async generateKeysIfNeeded() {
     let publicKeys: EosPublicKeys
     // get keys from paramters or freshly generated
-    publicKeys = this.getPublicKeysFromOptions()
+    publicKeys = this.getPublicKeysFromOptions() || {}
     const { owner, active } = publicKeys
     if (!owner || !active) {
       await this.generateAccountKeys(publicKeys)
@@ -313,13 +313,16 @@ export class EosCreateAccount implements CreateAccount {
     }
   }
 
-  /** Generate new public and private key pair if not passed in the function and stores them in class's generatedKeys
+  /** Generate new public and private key pair and stores them in class's generatedKeys
+   *  Allows existing publicKeys to be retained via overridePublicKeys
    *  Also adds the new keys to the class's options.publicKeys */
-  private async generateAccountKeys(publicKeys: EosPublicKeys): Promise<void> {
+  private async generateAccountKeys(overridePublicKeys: EosPublicKeys): Promise<void> {
     // generate new account owner/active keys if they weren't provided
     const { newKeysOptions } = this._options
     const { password, salt } = newKeysOptions || {}
-    const generatedKeys = await generateNewAccountKeysAndEncryptPrivateKeys(password, salt, { publicKeys })
+    const generatedKeys = await generateNewAccountKeysAndEncryptPrivateKeys(password, salt, {
+      publicKeys: overridePublicKeys,
+    })
     this._generatedKeys = {
       ...this._generatedKeys,
       accountKeys: generatedKeys,

--- a/src/chains/eos_1_8/helpers/generalModelHelpers.ts
+++ b/src/chains/eos_1_8/helpers/generalModelHelpers.ts
@@ -2,10 +2,14 @@ import moment from 'moment'
 import { EosDate, EosAsset, EosEntityName } from '../models/generalModels'
 import { isNullOrEmpty } from '../../../helpers'
 
+/**  Expects a format of time_point/time_point_sec
+ * Example here: https://eosio.stackexchange.com/questions/4830/can-we-store-date-on-eosio-table/4831
+ * */
 export function isValidEosDate(str: string): str is EosDate {
   if (isNullOrEmpty(str)) return false
   return str.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{2}\d+$/i) !== null
 }
+
 // A string representation of an EOSIO symbol, composed of a float with a precision of 4
 // ... and a symbol composed of capital letters between 1-7 letters separated by a space
 // example '1.0000 ABC'

--- a/src/chains/ethereum_1/helpers/cryptoModelHelpers.ts
+++ b/src/chains/ethereum_1/helpers/cryptoModelHelpers.ts
@@ -54,7 +54,7 @@ export function isValidEthereumSignature(
   return isValidSignature(v, r, s)
 }
 
-// For a given private key, pr, the Ethereum address A(pr) (a 160-bit value) to which it corresponds is defined as the right most 160-bits of the Keccak hash of the corresponding ECDSA public key.
+// For a given private key, pr, the Ethereum address A(pr) (a 160-bit value) is defined as the right most 160-bits of the Keccak hash of the corresponding ECDSA public key.
 export function isValidEthereumAddress(value: string | Buffer | EthereumAddress): boolean {
   if (typeof value === 'string') return isValidAddress(value)
   return true


### PR DESCRIPTION
Allows to pass owner keys for account creation. 
It was generating new owner keys and not overriding it with owner key passed in options