### PR TITLE
Fix/ethreum fetch gas price

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rights-exchange/chainjs",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "description": "Javascript helper library providing plug-in interfaces to multiple block chains.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/chains/ethereum_1/ethTransaction.ts
+++ b/src/chains/ethereum_1/ethTransaction.ts
@@ -31,6 +31,7 @@ import {
   toEthereumPublicKey,
   toEthereumAddress,
   isValidEthereumAddress,
+  toGweiFromWei,
 } from './helpers'
 import { EthereumActionHelper } from './ethAction'
 
@@ -113,7 +114,7 @@ export class EthereumTransaction implements Transaction {
     const { to, value, data } = this._actionHelper.raw
     // 0.000000001 * ... is the gasPrice multiplayer currently hardcoded, ready to be replaced by an optional parameter
     // Convert gas price returned from getGasPrice to Gwei
-    gasPrice = isNullOrEmpty(gasPrice) ? 0.000000001 * (await this._chainState.getGasPrice()) : gasPrice
+    gasPrice = isNullOrEmpty(gasPrice) ? toGweiFromWei(await this._chainState.getGasPrice()) : gasPrice
     gasLimit = isNullOrEmpty(gasLimit) ? (await this._chainState.getBlock(EthereumBlockType.Latest)).gasLimit : gasLimit
     // EthereumJsTx  expects gasPrice and gasLimit in Gwei
     const trxBody = { nonce, to, value, data, gasPrice, gasLimit }

--- a/src/chains/ethereum_1/ethTransaction.ts
+++ b/src/chains/ethereum_1/ethTransaction.ts
@@ -112,10 +112,10 @@ export class EthereumTransaction implements Transaction {
     let { gasPrice = null, gasLimit = null } = this._options || {}
     const { to, value, data } = this._actionHelper.raw
     // 0.000000001 * ... is the gasPrice multiplayer currently hardcoded, ready to be replaced by an optional parameter
-    // Value returned from getGasPrice is in wei. It is then converted to gwei
+    // Convert gas price returned from getGasPrice to Gwei
     gasPrice = isNullOrEmpty(gasPrice) ? 0.000000001 * (await this._chainState.getGasPrice()) : gasPrice
     gasLimit = isNullOrEmpty(gasLimit) ? (await this._chainState.getBlock(EthereumBlockType.Latest)).gasLimit : gasLimit
-    // gasPrice and gasLimit in Gwei
+    // EthereumJsTx  expects gasPrice and gasLimit in Gwei
     const trxBody = { nonce, to, value, data, gasPrice, gasLimit }
     this._raw = new EthereumJsTx(trxBody, trxOptions)
     this.setHeaderFromRaw()

--- a/src/chains/ethereum_1/ethTransaction.ts
+++ b/src/chains/ethereum_1/ethTransaction.ts
@@ -111,9 +111,11 @@ export class EthereumTransaction implements Transaction {
     const { nonce = null } = this._options || {}
     let { gasPrice = null, gasLimit = null } = this._options || {}
     const { to, value, data } = this._actionHelper.raw
-    // 1 * ... is the gasPrice multiplayer currently hardcoded, ready to be replaced by an optional parameter
-    gasPrice = isNullOrEmpty(gasPrice) ? 1 * (await this._chainState.getGasPrice()) : gasPrice
+    // 0.000000001 * ... is the gasPrice multiplayer currently hardcoded, ready to be replaced by an optional parameter
+    // Value returned from getGasPrice is in wei. It is then converted to gwei
+    gasPrice = isNullOrEmpty(gasPrice) ? 0.000000001 * (await this._chainState.getGasPrice()) : gasPrice
     gasLimit = isNullOrEmpty(gasLimit) ? (await this._chainState.getBlock(EthereumBlockType.Latest)).gasLimit : gasLimit
+    // gasPrice and gasLimit in Gwei
     const trxBody = { nonce, to, value, data, gasPrice, gasLimit }
     this._raw = new EthereumJsTx(trxBody, trxOptions)
     this.setHeaderFromRaw()

--- a/src/chains/ethereum_1/helpers/transactionHelpers.ts
+++ b/src/chains/ethereum_1/helpers/transactionHelpers.ts
@@ -30,6 +30,12 @@ export function toWei(amount: number | BN, type: EthUnit) {
   return web3.utils.toWei(new BN(amount), type)
 }
 
+/** Converts wei amount to Gwei
+ *  1 Gwei = 1000000000 wei */
+export function toGweiFromWei(amount: number | BN) {
+  return 0.000000001 * (amount as number)
+}
+
 /** Checks if nullOrEmpty and ethereum spesific hexadecimal and Buffer values that implies empty */
 export function ethereumTrxArgIsNullOrEmpty(obj: any) {
   if (


### PR DESCRIPTION
Gas price was sent to the EthereumTx transaction builder in Wei however it expects the value in Gwei (1 Gwei = 1000000000 wei).  As a result the transaction sent to the chain error out with 'insufficient funds' error. 